### PR TITLE
Improve help command and add support for custom command prefix (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ The command role is the ID of any role on the server the bot is hosted for, any 
   - Send a message in Discord when people join or leave the guild, and when people login or logout of Hypixel.
 - [ ] Add support for officer chat
   - Allocate a second discord channel to use for two way officer chat.
-- [ ] Add more commands for staff to use
-  - !invite, !kick, !promote, !demote, !ban, !unban
 
 ## License
 

--- a/config.example.json
+++ b/config.example.json
@@ -12,6 +12,7 @@
   "discord": {
     "token": "discordBotToken",
     "channel": "channelId",
-    "commandRole": "roleId"
+    "commandRole": "roleId",
+    "prefix": "!"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/discord/commands/CommandHandler.js
+++ b/src/discord/commands/CommandHandler.js
@@ -1,46 +1,48 @@
-const config = require('../../../config.json')
-const RelogCommand = require('./RelogCommand')
-const HelpCommand = require('./HelpCommand')
-const InviteCommand = require('./InviteCommand')
-const KickCommand = require('./KickCommand')
-const PromoteCommand = require('./PromoteCommand')
-const DemoteCommand = require('./DemoteCommand')
-const OverrideCommand = require('./OverrideCommand')
-const MuteCommand = require('./MuteCommand')
+const RelogCommand = require(`./RelogCommand`)
+const HelpCommand = require(`./HelpCommand`)
+const InviteCommand = require(`./InviteCommand`)
+const KickCommand = require(`./KickCommand`)
+const PromoteCommand = require(`./PromoteCommand`)
+const DemoteCommand = require(`./DemoteCommand`)
+const OverrideCommand = require(`./OverrideCommand`)
+const MuteCommand = require(`./MuteCommand`)
+
+const config = require(`../../../config.json`)
+const prefix = config.discord.prefix
 
 class CommandHandler {
   constructor(discord) {
     this.commands = [
       {
-        trigger: ['!relog', '!r'],
+        trigger: [`${prefix}relog`, `${prefix}r`],
         handler: new RelogCommand(discord),
       },
       {
-        trigger: ['!help', '!h'],
+        trigger: [`${prefix}help`, `${prefix}h`],
         handler: new HelpCommand(discord),
       },
       {
-        trigger: ['!invite', '!inv', '!i'],
+        trigger: [`${prefix}invite`, `${prefix}inv`, `${prefix}i`],
         handler: new InviteCommand(discord),
       },
       {
-        trigger: ['!kick', '!k'],
+        trigger: [`${prefix}kick`, `${prefix}k`],
         handler: new KickCommand(discord),
       },
       {
-        trigger: ['!promote', '!up', '!p'],
+        trigger: [`${prefix}promote`, `${prefix}up`, `${prefix}p`],
         handler: new PromoteCommand(discord),
       },
       {
-        trigger: ['!demote', '!down', '!d'],
+        trigger: [`${prefix}demote`, `${prefix}down`, `${prefix}d`],
         handler: new DemoteCommand(discord),
       },
       {
-        trigger: ['!override', '!or', '!o'],
+        trigger: [`${prefix}override`, `${prefix}or`, `${prefix}o`],
         handler: new OverrideCommand(discord),
       },
       {
-        trigger: ['!mute', '!m'],
+        trigger: [`${prefix}mute`, `${prefix}m`],
         handler: new MuteCommand(discord),
       },
     ]
@@ -63,7 +65,9 @@ class CommandHandler {
   }
 
   runCommand(command, message) {
-    if (!this.isCommander(message.member)) {
+    if (message.content == `${prefix}h` || message.content == `${prefix}help`) {
+      return command.handler.onCommand(message)
+    } else if (!this.isCommander(message.member)) {
       return message.reply("You're not allowed to run this command!")
     }
 

--- a/src/discord/commands/HelpCommand.js
+++ b/src/discord/commands/HelpCommand.js
@@ -1,6 +1,10 @@
 const DiscordCommand = require('../../contracts/DiscordCommand')
 const Discord = require('discord.js-light')
 
+const { version } = require('../../../package.json')
+const config = require('../../../config.json')
+const prefix = config.discord.prefix
+
 const helpEmbed = new Discord.MessageEmbed()
   .setTitle('Help')
   .setDescription('`< >` = Required arguments\n`[ ]` = Optional arguments')
@@ -8,32 +12,44 @@ const helpEmbed = new Discord.MessageEmbed()
     {
       name: `Command list`,
       value: [
-        '`!help` - Displays this command list',
-        '`!relog [delay]` - Relogs the MC client, a delay can be given in seconds, if no delay is given it will default to 5 seconds',
-        '`!override <command> [args]` - Executes the string attached. **This is a dangerous permission to grant**',
-        "`!invite <player>` - Invites the specified user to the guild, providing the guild isn't full",
-        '`!kick <user> [reason]` - Kicks the specified user from the guild',
-        '`!promote <user>` - Promotes the specified user by 1 rank',
-        '`!demote <user>` - Demotes the specified user by 1 rank',
-        '`!mute <user>` - Demotes the specified user by 1 rank',
+        '`help` - Displays this command list',
+        '`relog [delay]` - Relogs the MC client, a delay can be given in seconds, if no delay is given it will default to 5 seconds',
+        '`override <command> [args]` - Executes the string attached. **This is a dangerous permission to grant**',
+        "`invite <player>` - Invites the specified user to the guild, providing the guild isn't full",
+        '`kick <user> [reason]` - Kicks the specified user from the guild',
+        '`promote <user>` - Promotes the specified user by 1 rank',
+        '`demote <user>` - Demotes the specified user by 1 rank',
+        '`mute <user>` - Demotes the specified user by 1 rank',
       ].join('\n'),
     },
     {
       name: `Shortcuts`,
       value: [
-        'Help: `!h`',
-        'Relog: `!r`',
-        'Override: `!o`, `!or`',
-        'Invite: `!i`, `!inv`',
-        'Kick: `!k`',
-        'Promote: `!p`, `!up`',
-        'Demote: `!d`, `!down`',
-        'Mute: `!m`',
+        'Help: `h`',
+        'Relog: `r`',
+        'Override: `o`, `or`',
+        'Invite: `i`, `inv`',
+        'Kick: `k`',
+        'Promote: `p`, `up`',
+        'Demote: `d`, `down`',
+        'Mute: `m`',
       ].join('\n'),
+      inline: true,
+    },
+    {
+      name: `Info`,
+      value: [
+        `Prefix: \`${prefix}\``,
+        `Guild Channel: <#${config.discord.channel}>`,
+        //`Officer Channel: \`Still in development\``
+        `Command Role: <@&${config.discord.commandRole}>`,
+        `Version: \`${version}\``,
+      ].join('\n'),
+      inline: true,
     }
   )
   .setTimestamp()
-  .setFooter('Made by Senither#0001')
+  .setFooter('Made by Senither and neyoa ❤')
 
 class HelpCommand extends DiscordCommand {
   onCommand(message) {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -20,8 +20,7 @@ class StateHandler extends EventHandler {
 
     if (this.isLobbyJoinMessage(message)) {
       console.log('Sending Minecraft client to limbo')
-
-      return this.bot.chat('§')
+      return this.bot.chat('/ac §')
     }
 
     if (!this.isGuildMessage(message)) {


### PR DESCRIPTION
* Changed limbo trigger to say in all chat

* Added Info section to help embed

* Updated Discord CommandHandler to enable prefixes other than `!`

* Fixed help info not properly mentioning command role

* Allow all users to use the help command

* Bump version

* Update README.md

* Fix formatting

* Improve help command imports

Co-authored-by: Alexis Tan <alexis@sen-dev.com>